### PR TITLE
Fix Thumbnails

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/source/SourceManager.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/source/SourceManager.kt
@@ -101,7 +101,7 @@ open class SourceManager(private val context: Context) {
         exSrcs += NHentai(context)
         exSrcs += HentaiCafe()
         exSrcs += Tsumino(context)
-        exSrcs += Hitomi(context)
+        //exSrcs += Hitomi(context)
         return exSrcs
     }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/source/online/all/EHentai.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/source/online/all/EHentai.kt
@@ -75,14 +75,12 @@ class EHentai(override val id: Long,
                             url = ExGalleryMetadata.normalizeUrl(attr("href"))
                         }
                         //Get image
-                        it.parent().selectFirst(".glthumb")?.apply {
+                        it.parent().selectFirst("div[id^=posted_]")?.apply {
                             thumbnail_url = this.selectFirst("img")
                                     ?.attr("src")?.nullIfBlank()
-                                    ?: this.selectFirst("img")?.attr("src")
-                                            ?.nullIfBlank()
-                                            ?: parseInitsMeta(it.parent()
-                                                .selectFirst(".glthumb")
-                                                .childNode(0).toString())
+                                    ?: parseInitsMeta(it.parent()
+                                            .selectFirst(".glthumb")
+                                            .childNode(0).toString())
                         }
                     })
         }

--- a/app/src/main/java/eu/kanade/tachiyomi/source/online/all/EHentai.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/source/online/all/EHentai.kt
@@ -66,8 +66,7 @@ class EHentai(override val id: Long,
         //Parse mangas
         val parsedMangas = select("table.itg td.glname").map {
             ParsedManga(
-                    //fav = -1,//parseFavoritesStyle(it.select(".itd .it3 > .i[id]").first()?.attr("style")), // TODO" fix
-                    fav = parseFavoritesStyle(it.parent().childNode(1).childNode(1).attr("style")),
+                    fav = parseFavoritesStyle(it.parent().selectFirst(".gl2c").childNode(1).attr("style")),
                     manga = Manga.create(id).apply {
                         //Get title
                         it.select("a").first()?.apply {


### PR DESCRIPTION
This requires a cache clear to show results, as urls are stored and not overridden per `Manga` item, which was a pain in debugging

I also just disabled hitomi to mitigate crashing